### PR TITLE
Atualização do significado de "neoliberal".

### DIFF
--- a/src/library.json
+++ b/src/library.json
@@ -74,7 +74,7 @@
   "magistratura": "galera que decide a porra toda",
   "medida provisória": "gato na regra do jogo",
   "meritocracia": "desculpa esfarrapada que rico dâ pra não se sentir mal com a miséria do povo",
-  "neoliberal": "pessoa que pensa que em economia não se importando com regras ou regulamentações legais",
+  "neoliberal": "pessoa que pensa em economia não se importando com regras ou regulamentações legais",
   "nepotismo": "dar um jeitinho e colocar os parças para trabalhar",
   "offshore": "empresa nas gringas pra guardar dinheiro desviado",
   "oligarquia": "famílias poderosas",


### PR DESCRIPTION
Apenas uma modificação sobre o valor da chave "neoliberal", uma vez que existe um "que" duplicado e, aparentemente, esse não era o objetivo inicial na formulação do significado.