### PR TITLE
bug fix no arquivo library.json

### DIFF
--- a/src/library.json
+++ b/src/library.json
@@ -73,7 +73,7 @@
   "lei da ficha limpa": "lei que politicos com crimes comprovados não concorrem",
   "leviano": "só faz merda",
   "liberalismo": "cada um paga o seu",
-  "libertarianismo": "faz o que tu queres, há de ser tudo da lei"",
+  "libertarianismo": "faz o que tu queres, há de ser tudo da lei",
   "lícito": "dentro da lei",
   "lobby": "pressão para influenciar na tomada de decisões",
   "machismo": "mulher < homem",


### PR DESCRIPTION
### Descrição

O arquivo **library.json** estava com uma string quebrada na palavra **libertarianismo**, pois tinha uma aspa dupla a mais.

 